### PR TITLE
If message came in over 15 minutes before the app booted, then ignore…

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 	"go.mau.fi/whatsmeow/store/sqlstore"
@@ -15,7 +16,13 @@ var (
 	LogLevel  = "DEBUG"
 	db        = os.Getenv("DATABASE")
 	redisAddr = os.Getenv("REDIS_ADDR")
+
+	boottime time.Time
 )
+
+func init() {
+	boottime = time.Now()
+}
 
 func main() {
 	dbLog := waLog.Stdout("Database", LogLevel, true)


### PR DESCRIPTION
… it.

This is important for when the app restarts and gets a new database instance, such as if the underlying hardware goes away or the cluster on which it runs goes to hell

This is, in effect, a core component of our DR strategy- should we bring the app back from an outage and need to re-QR then we don't want to have to react to every message we've ever seen or else we're just going to spam the hell out of everyone.

The 15 minutes gives us some safety in case getting the phone and QR-ing takes too long and we miss messages