### PR TITLE
Mark 'recently sent' on response from slack

### DIFF
--- a/client.go
+++ b/client.go
@@ -202,6 +202,8 @@ func (c Client) HandleResponse(msg Message) (err error) {
 		Conversation: stringRef(msg.Message),
 	})
 
+	c.r.MarkRecentlySent(thankyouKey(msg.ID), time.Minute*30)
+
 	return
 }
 


### PR DESCRIPTION
We run into a weird situation where:

1. Recipient (R) sends a message to the bot at 1200 (for example)
2. Advisor (A) sends a resonse to the bot at 1231
3. R sends a message back at 1232
4. Bot (B) sends a thank you message

In this situation R and A are in an active conversation, yet B sends a response as if R has just initiated a response. This is because as far as B is concerned, it has been over 30 minutes since the last message.

In this situation, then, we reset the 'Thank you' response on all responses; whether from R or A. This removes the absurdity