### PR TITLE
Set status message to whatsapp

### DIFF
--- a/client.go
+++ b/client.go
@@ -28,6 +28,7 @@ type whatsappClient interface {
 	MarkRead([]string, time.Time, types.JID, types.JID) error
 	SendMessage(context.Context, types.JID, string, *waProto.Message) (whatsmeow.SendResponse, error)
 	SendPresence(types.Presence) error
+	SetStatusMessage(string) error
 }
 
 type Client struct {
@@ -72,7 +73,12 @@ func (c *Client) connect() (err error) {
 		return
 	}
 
-	return c.c.Connect()
+	err = c.c.Connect()
+	if err != nil {
+		return
+	}
+
+	return c.c.SetStatusMessage(statusMessage)
 }
 
 func (c *Client) disconnect() {

--- a/config.go
+++ b/config.go
@@ -12,6 +12,10 @@ var (
 	// Disclaimer response is sent to ensure recipients don't send us stuff we can't deal with.
 	disclaimerResponse = Lookup("DISCLAIMER", "DISCLAIMER: This is not an incident reporting service. If you believe you're being subjected to bullying, harassment, or misconduct then I cannot escalate on your behalf but I can advise you on your next steps.")
 
+	// Status message is sent on startup and sets the bot's status from the default of
+	// `Hey there! I am using WhatsApp.`
+	statusMessage = Lookup("STATUS", "Hello, my name is Ada!")
+
 	// DB is the location, on disk, of the database to use
 	db = MustLookup("DATABASE")
 


### PR DESCRIPTION
Currently the bot either needs a status setting manually, via the phone, or left as "Hey there! I am using WhatsApp." - which kinda sucks.

This change allows us to set it from the bot