### PR TITLE
Upgrade types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/agnivade/levenshtein v1.1.1
-	github.com/gender-equality-community/types v1.1.0
+	github.com/gender-equality-community/types v1.2.0
 	github.com/go-redis/redis/v9 v9.0.0-beta.2
 	github.com/mattn/go-sqlite3 v1.14.15
 	github.com/mdp/qrterminal v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cu
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
-github.com/gender-equality-community/types v1.1.0 h1:7dvZkcSeA31bE4fin+yx5eejEtsqLb1Po4FjHOXny/Y=
-github.com/gender-equality-community/types v1.1.0/go.mod h1:zSavH17hq7FtUZysU9m2vwflJzJLcTxe7/OD6V3DB+g=
+github.com/gender-equality-community/types v1.2.0 h1:mdbkBCHUzHDCKHMlAmnXfC6BiCHca9zyQvNJX9gv7SI=
+github.com/gender-equality-community/types v1.2.0/go.mod h1:zSavH17hq7FtUZysU9m2vwflJzJLcTxe7/OD6V3DB+g=
 github.com/go-redis/redis/v9 v9.0.0-beta.2 h1:ZSr84TsnQyKMAg8gnV+oawuQezeJR11/09THcWCQzr4=
 github.com/go-redis/redis/v9 v9.0.0-beta.2/go.mod h1:Bldcd/M/bm9HbnNPi/LUtYBSD8ttcZYBMupwMXhdU0o=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=


### PR DESCRIPTION
Previously all reads and writes to/from redis were bombing out because types.Source couldn't be marshalled. This fixes that