### PR TITLE
Disable sonarscan for dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
   sonarcloud:
     needs: test
     runs-on: ubuntu-latest
+    if: ${{ github.triggering_actor != 'dependabot[bot]' }}
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Dependabot PRs don't have access to build secrets, such as the token we need to use to authenticate with sonarcloud.

The current dependabot workflow requires us to manually check each PR to ensure only the sonarcloud step failed (and that stuff like tests are fine) which causes friction and toil.

This change will allow us to even go as far as automerging dependabot, should we want to- our dependabot PRs will actually become useful and friction-free